### PR TITLE
fix: use u32 instead of usize for Mbc1Snapshot.bank_num

### DIFF
--- a/crates/gb_cartridge/src/mbc/mbc1.rs
+++ b/crates/gb_cartridge/src/mbc/mbc1.rs
@@ -131,7 +131,7 @@ impl super::Mbc for Mbc1 {
 struct Mbc1Snapshot {
     bank_mode: u8,
     ram_enabled: bool,
-    bank_num: usize,
+    bank_num: u32,
     ram_banks: Vec<u8>,
     with_battery: bool,
 }
@@ -148,7 +148,7 @@ impl Snapshot for Mbc1 {
         bincode::serialize(&Mbc1Snapshot {
             bank_mode: self.bank_mode,
             ram_enabled: self.ram_enabled,
-            bank_num: self.bank_num,
+            bank_num: self.bank_num as u32,
             ram_banks: ram_banks_snapshot,
             with_battery: self.with_battery,
         })
@@ -162,7 +162,7 @@ impl Snapshot for Mbc1 {
 
         self.bank_mode = bank_mode;
         self.ram_enabled = ram_enabled;
-        self.bank_num = bank_num;
+        self.bank_num = bank_num as usize;
         self.with_battery = with_battery;
 
         ram_banks.chunks(kib(8)).zip(&mut self.ram_banks).for_each(|(src, dst)| {


### PR DESCRIPTION
usize is platform-dependent and causes bincode to serialize different
byte widths on 32-bit vs 64-bit targets, making snapshots non-portable.

https://claude.ai/code/session_01MY6XagH9Ut6biewWJ1s8Mw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced save game serialization format for improved reliability and cross-platform compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nomyfan/gameboy-emulator/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->